### PR TITLE
Add Deque demo and Queue/Deque use-case pages; align Queue UI

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter as Router, Routes, Route, NavLink, Navigate } from "react-router-dom";
 import StackComponent from "./components/StackComponent";
 import QueueComponent from "./components/QueueComponent";
+import DequeComponent from "./components/DequeComponent";
 import InvertedQueueComponent from "./components/InvertedQueueComponent";
 import HashTableComponent from "./components/HashTableComponent";
 import LinkedListComponent from "./components/LinkedListComponent";
@@ -10,6 +11,8 @@ import TreeComponent from "./components/TreeComponent";
 import ArraysComponent from "./components/ArraysComponent";
 import ArrayUseCaseComponent from "./components/ArrayUseCaseComponent";
 import StackUseCaseComponent from "./components/StackUseCaseComponent";
+import QueueUseCaseComponent from "./components/QueueUseCaseComponent";
+import DequeUseCaseComponent from "./components/DequeUseCaseComponent";
 
 export default function App() {
     return (
@@ -32,6 +35,9 @@ export default function App() {
                             </li>
                             <li className="nav-item">
                                 <NavLink className="nav-link" to="/queue">Queue</NavLink>
+                            </li>
+                            <li className="nav-item">
+                                <NavLink className="nav-link" to="/deque">Deque</NavLink>
                             </li>
                             <li className="nav-item">
                                 <NavLink className="nav-link" to="/inverted-queue">Inverted Queue</NavLink>
@@ -62,6 +68,12 @@ export default function App() {
                         <NavLink className="btn btn-sm btn-outline-primary" to="/use-cases/stacks">
                             Stack Use Case
                         </NavLink>
+                        <NavLink className="btn btn-sm btn-outline-primary" to="/use-cases/queue">
+                            Queue Use Case
+                        </NavLink>
+                        <NavLink className="btn btn-sm btn-outline-primary" to="/use-cases/deque">
+                            Deque Use Case
+                        </NavLink>
                     </div>
                 </div>
 
@@ -70,6 +82,7 @@ export default function App() {
                     <Route path="/arrays" element={<ArraysComponent />} />
                     <Route path="/stack" element={<StackComponent />} />
                     <Route path="/queue" element={<QueueComponent />} />
+                    <Route path="/deque" element={<DequeComponent />} />
                     <Route path="/inverted-queue" element={<InvertedQueueComponent />} />
                     <Route path="/hash-table" element={<HashTableComponent />} />
                     <Route path="/linked-list" element={<LinkedListComponent />} />
@@ -77,6 +90,8 @@ export default function App() {
                     <Route path="/tree" element={<TreeComponent />} />
                     <Route path="/use-cases/arrays" element={<ArrayUseCaseComponent />} />
                     <Route path="/use-cases/stacks" element={<StackUseCaseComponent />} />
+                    <Route path="/use-cases/queue" element={<QueueUseCaseComponent />} />
+                    <Route path="/use-cases/deque" element={<DequeUseCaseComponent />} />
                     <Route path="*" element={<Navigate to="/arrays" replace />} />
                 </Routes>
             </div>

--- a/src/components/DequeComponent.js
+++ b/src/components/DequeComponent.js
@@ -1,0 +1,86 @@
+import React, { useState } from "react";
+
+export default function DequeComponent() {
+    const [deque, setDeque] = useState(["Middle"]);
+    const [input, setInput] = useState("");
+    const [output, setOutput] = useState("Add items to either end of the deque.");
+
+    const addFront = () => {
+        if (!input.trim()) {
+            setOutput("Please enter a value to add to the front.");
+            return;
+        }
+
+        const nextValue = input.trim();
+        setDeque([nextValue, ...deque]);
+        setInput("");
+        setOutput(`Added to front: ${nextValue}`);
+    };
+
+    const addBack = () => {
+        if (!input.trim()) {
+            setOutput("Please enter a value to add to the back.");
+            return;
+        }
+
+        const nextValue = input.trim();
+        setDeque([...deque, nextValue]);
+        setInput("");
+        setOutput(`Added to back: ${nextValue}`);
+    };
+
+    const removeFront = () => {
+        if (deque.length === 0) {
+            setOutput("Deque is empty!");
+            return;
+        }
+
+        const removed = deque[0];
+        setDeque(deque.slice(1));
+        setOutput(`Removed from front: ${removed}`);
+    };
+
+    const removeBack = () => {
+        if (deque.length === 0) {
+            setOutput("Deque is empty!");
+            return;
+        }
+
+        const removed = deque[deque.length - 1];
+        setDeque(deque.slice(0, -1));
+        setOutput(`Removed from back: ${removed}`);
+    };
+
+    return (
+        <div className="card shadow-sm p-4">
+            <h2 className="mb-2">Deque Operations</h2>
+            <p className="text-muted mb-4">A deque (double-ended queue) lets you add and remove items from both the front and back.</p>
+
+            <div className="input-group mb-3">
+                <input
+                    type="text"
+                    className="form-control"
+                    placeholder="Enter value"
+                    value={input}
+                    onChange={(e) => setInput(e.target.value)}
+                />
+                <button className="btn btn-primary" onClick={addFront}>Add Front</button>
+                <button className="btn btn-primary" onClick={addBack}>Add Back</button>
+            </div>
+
+            <div className="d-flex flex-wrap gap-2 mb-3">
+                <button className="btn btn-danger" onClick={removeFront}>Remove Front</button>
+                <button className="btn btn-danger" onClick={removeBack}>Remove Back</button>
+            </div>
+
+            <div className="alert alert-info">
+                <strong>Output:</strong> {output}
+            </div>
+
+            <div className="border rounded p-3">
+                <h5>Current Deque (front → back):</h5>
+                <p className="mb-0">{deque.length ? deque.join(" → ") : "Deque is empty."}</p>
+            </div>
+        </div>
+    );
+}

--- a/src/components/DequeUseCaseComponent.js
+++ b/src/components/DequeUseCaseComponent.js
@@ -1,0 +1,88 @@
+import React, { useState } from "react";
+
+export default function DequeUseCaseComponent() {
+    const [tasks, setTasks] = useState(["Daily backup", "Email triage", "Bug fix"]);
+    const [taskInput, setTaskInput] = useState("");
+    const [output, setOutput] = useState("Add urgent work to the front or routine work to the back.");
+
+    const addUrgentTask = () => {
+        if (!taskInput.trim()) {
+            setOutput("Please enter a task before adding.");
+            return;
+        }
+
+        const taskValue = taskInput.trim();
+        setTasks([taskValue, ...tasks]);
+        setTaskInput("");
+        setOutput(`Urgent task added to front: ${taskValue}`);
+    };
+
+    const addRoutineTask = () => {
+        if (!taskInput.trim()) {
+            setOutput("Please enter a task before adding.");
+            return;
+        }
+
+        const taskValue = taskInput.trim();
+        setTasks([...tasks, taskValue]);
+        setTaskInput("");
+        setOutput(`Routine task added to back: ${taskValue}`);
+    };
+
+    const completeNextTask = () => {
+        if (tasks.length === 0) {
+            setOutput("No tasks available.");
+            return;
+        }
+
+        const completed = tasks[0];
+        setTasks(tasks.slice(1));
+        setOutput(`Completed front task: ${completed}`);
+    };
+
+    const completeLowPriorityTask = () => {
+        if (tasks.length === 0) {
+            setOutput("No tasks available.");
+            return;
+        }
+
+        const completed = tasks[tasks.length - 1];
+        setTasks(tasks.slice(0, -1));
+        setOutput(`Completed back task: ${completed}`);
+    };
+
+    return (
+        <div className="card shadow-sm p-4">
+            <h2 className="mb-2">Use Case: Deque for Task Scheduling</h2>
+            <p className="text-muted mb-4">
+                A deque is useful when a scheduler must insert and remove tasks at both ends—for example, urgent tickets at the front and batch jobs at the back.
+            </p>
+
+            <div className="input-group mb-3">
+                <input
+                    type="text"
+                    className="form-control"
+                    placeholder="Enter task"
+                    value={taskInput}
+                    onChange={(e) => setTaskInput(e.target.value)}
+                />
+                <button className="btn btn-primary" onClick={addUrgentTask}>Add Urgent (Front)</button>
+                <button className="btn btn-primary" onClick={addRoutineTask}>Add Routine (Back)</button>
+            </div>
+
+            <div className="d-flex flex-wrap gap-2 mb-3">
+                <button className="btn btn-success" onClick={completeNextTask}>Complete Front Task</button>
+                <button className="btn btn-success" onClick={completeLowPriorityTask}>Complete Back Task</button>
+            </div>
+
+            <div className="alert alert-info">
+                <strong>Output:</strong> {output}
+            </div>
+
+            <div className="border rounded p-3">
+                <h5>Task Deque (front → back)</h5>
+                <p className="mb-0">{tasks.length ? tasks.join(" → ") : "No scheduled tasks."}</p>
+            </div>
+        </div>
+    );
+}

--- a/src/components/QueueComponent.js
+++ b/src/components/QueueComponent.js
@@ -3,13 +3,18 @@ import React, { useState } from "react";
 export default function QueueComponent() {
     const [queue, setQueue] = useState([]);
     const [input, setInput] = useState("");
-    const [output, setOutput] = useState("");
+    const [output, setOutput] = useState("Start by enqueuing an item.");
 
     const enqueue = () => {
-        if (!input) return;
-        setQueue([...queue, input]);
+        if (!input.trim()) {
+            setOutput("Please enter a value to enqueue.");
+            return;
+        }
+
+        const nextValue = input.trim();
+        setQueue([...queue, nextValue]);
         setInput("");
-        setOutput(`Enqueued: ${input}`);
+        setOutput(`Enqueued: ${nextValue}`);
     };
 
     const dequeue = () => {
@@ -24,7 +29,8 @@ export default function QueueComponent() {
 
     return (
         <div className="card shadow-sm p-4">
-            <h2 className="mb-4">Queue Operations</h2>
+            <h2 className="mb-2">Queue Operations</h2>
+            <p className="text-muted mb-4">Queues follow FIFO (First In, First Out): the earliest item added is removed first.</p>
 
             <div className="input-group mb-3">
                 <input
@@ -40,12 +46,12 @@ export default function QueueComponent() {
             <button className="btn btn-danger mb-3" onClick={dequeue}>Dequeue</button>
 
             <div className="alert alert-info">
-                <strong>Output:</strong> {output || "No operations yet."}
+                <strong>Output:</strong> {output}
             </div>
 
             <div className="border rounded p-3">
-                <h5>Current Queue:</h5>
-                <p>{queue.length ? queue.join(" -> ") : "Queue is empty."}</p>
+                <h5>Current Queue (front → back):</h5>
+                <p className="mb-0">{queue.length ? queue.join(" → ") : "Queue is empty."}</p>
             </div>
         </div>
     );

--- a/src/components/QueueUseCaseComponent.js
+++ b/src/components/QueueUseCaseComponent.js
@@ -1,0 +1,67 @@
+import React, { useState } from "react";
+
+const initialOrders = [
+    "Order #1001 - Latte",
+    "Order #1002 - Cappuccino",
+    "Order #1003 - Tea"
+];
+
+export default function QueueUseCaseComponent() {
+    const [orders, setOrders] = useState(initialOrders);
+    const [newOrder, setNewOrder] = useState("");
+    const [output, setOutput] = useState("New orders join the back of the line.");
+
+    const addOrder = () => {
+        if (!newOrder.trim()) {
+            setOutput("Please enter an order description.");
+            return;
+        }
+
+        const orderValue = newOrder.trim();
+        setOrders([...orders, orderValue]);
+        setNewOrder("");
+        setOutput(`Added to queue: ${orderValue}`);
+    };
+
+    const serveOrder = () => {
+        if (orders.length === 0) {
+            setOutput("No orders left to serve.");
+            return;
+        }
+
+        const served = orders[0];
+        setOrders(orders.slice(1));
+        setOutput(`Served: ${served}`);
+    };
+
+    return (
+        <div className="card shadow-sm p-4">
+            <h2 className="mb-2">Use Case: Queue for Order Processing</h2>
+            <p className="text-muted mb-4">
+                Cafés and help desks often process requests in arrival order. A queue ensures fairness with FIFO behavior.
+            </p>
+
+            <div className="input-group mb-3">
+                <input
+                    type="text"
+                    className="form-control"
+                    placeholder="Enter new order"
+                    value={newOrder}
+                    onChange={(e) => setNewOrder(e.target.value)}
+                />
+                <button className="btn btn-primary" onClick={addOrder}>Add Order</button>
+            </div>
+
+            <button className="btn btn-success mb-3" onClick={serveOrder}>Serve Next Order</button>
+
+            <div className="alert alert-info">
+                <strong>Output:</strong> {output}
+            </div>
+
+            <div className="border rounded p-3">
+                <h5>Order Queue (front → back)</h5>
+                <p className="mb-0">{orders.length ? orders.join(" → ") : "No pending orders."}</p>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
### Motivation

- Bring the Queue example in line with the Stack/Array pages by adding clearer guidance text, consistent output formatting, and input validation.\
- Provide a hands-on `Deque` demo so learners can experiment with double-ended operations.\
- Offer real-world examples for both `Queue` and `Deque` to show practical workflows (order processing and task scheduling).\
- Make the new examples discoverable by wiring them into the main navigation and the Use Cases section.

### Description

- Updated `src/components/QueueComponent.js` to add starter output, input trimming/validation, clearer explanatory text, and consistent front→back visualization.\
- Added a new interactive `Deque` example in `src/components/DequeComponent.js` with `Add Front`, `Add Back`, `Remove Front`, and `Remove Back` operations and unified output formatting.\
- Added `src/components/QueueUseCaseComponent.js` (order processing FIFO) and `src/components/DequeUseCaseComponent.js` (task scheduling with urgent/front and routine/back behavior) as real-world use-case pages.\
- Wired imports, routes, and navigation buttons for `Deque`, `Queue Use Case`, and `Deque Use Case` in `src/App.js` so the new pages appear in the top nav and Use Cases area.

### Testing

- Attempted `npm run build` which failed because the repository does not define a `build` script (reported as not available).\
- Started the dev server with `npm start`, which compiled successfully before the process was intentionally stopped.\
- Captured UI verification screenshots using a Playwright script against `http://127.0.0.1:3000/deque` and `http://127.0.0.1:3000/use-cases/deque`, and artifacts were produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adc83fbd98832e8e4f3f17d7912a70)